### PR TITLE
Fingers & Pointables on hands, improve FingerType, replace deprecated sleep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ cmake = "0.1"
 [dependencies]
 libc = "0.2"
 
-[dev-dependencies]
-rustbox = "0.11"
+# [dev-dependencies]
+# rustbox = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ cmake = "0.1"
 [dependencies]
 libc = "0.2"
 
-# [dev-dependencies]
-# rustbox = "0.11"
+[dev-dependencies]
+rustbox = "0.11"

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,7 +1,9 @@
 extern crate leap;
 
+use std::thread::sleep;
+use std::time::Duration;
+
 use leap::Controller;
-use std::thread::sleep_ms;
 
 fn main() {
     let controller = Controller::new();
@@ -28,6 +30,6 @@ fn main() {
         } else {
             println!("Not connected!");
         }
-        sleep_ms(150);
+        sleep(Duration::from_millis(150));
     }
 }

--- a/examples/listener.rs
+++ b/examples/listener.rs
@@ -1,13 +1,15 @@
 extern crate leap;
 
+use std::thread::sleep;
+use std::time::Duration;
+
 use leap::Controller;
-use std::thread::sleep_ms;
 
 fn main() {
-    let controller = Controller::with_listener(DemoListener);
+    let _controller = Controller::with_listener(DemoListener);
     loop {
         // Do something else
-        sleep_ms(150);
+        sleep(Duration::from_millis(150));
     }
 }
 
@@ -57,6 +59,6 @@ impl leap::Listener for DemoListener {
         }
 
         println!("--------------------------------");
-        sleep_ms(150);
+        sleep(Duration::from_millis(150));
     }
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,9 +1,7 @@
+use std::{ops::Deref, ptr};
+
+use super::{DeviceList, Frame, Listener};
 use raw;
-use std::ops::Deref;
-use std::ptr;
-use DeviceList;
-use Frame;
-use Listener;
 
 pub struct Controller {
     raw: *mut raw::Controller,

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,7 +1,8 @@
+use std::{ffi::CStr, str::Utf8Error};
+
 use libc::{c_char, c_int, c_void};
+
 use raw;
-use std::ffi::CStr;
-use std::str::Utf8Error;
 
 pub struct Device {
     raw: *mut raw::Device,

--- a/src/finger.rs
+++ b/src/finger.rs
@@ -1,8 +1,10 @@
-use std::fmt::{self, Display, Formatter};
-use std::os::raw::c_int;
+use std::{
+    fmt::{self, Display, Formatter},
+    os::raw::c_int,
+};
 
+use super::Vector;
 use raw;
-use Vector;
 
 pub struct Finger {
     raw: *mut raw::Finger,

--- a/src/finger.rs
+++ b/src/finger.rs
@@ -159,7 +159,7 @@ impl<'a> Iterator for Iter<'a> {
 }
 
 /// Finger type
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, Hash)]
 pub enum FingerType {
     /// The thumb
     Thumb,

--- a/src/finger.rs
+++ b/src/finger.rs
@@ -159,7 +159,7 @@ impl<'a> Iterator for Iter<'a> {
 }
 
 /// Finger type
-#[derive(Copy, Clone, Debug, Hash)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub enum FingerType {
     /// The thumb
     Thumb,

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,8 +1,5 @@
+use super::{FingerList, HandList, InteractionBox, PointableList};
 use raw;
-use FingerList;
-use HandList;
-use InteractionBox;
-use PointableList;
 
 pub struct Frame {
     raw: *mut raw::Frame,

--- a/src/hand.rs
+++ b/src/hand.rs
@@ -1,6 +1,7 @@
-use raw;
 use std::os::raw::c_int;
-use Vector;
+
+use super::{FingerList, PointableList, Vector};
+use raw;
 
 pub struct Hand {
     raw: *mut raw::Hand,
@@ -18,6 +19,14 @@ impl Hand {
 
     pub fn pinch_distance(&self) -> f32 {
         unsafe { raw::lm_hand_pinch_distance(self.raw) }
+    }
+
+    pub fn fingers(&self) -> FingerList {
+        unsafe { FingerList::from_raw(raw::lm_hand_fingers(self.raw)) }
+    }
+
+    pub fn pointables(&self) -> PointableList {
+        unsafe { PointableList::from_raw(raw::lm_hand_pointables(self.raw)) }
     }
 
     pub fn stabilized_palm_position(&self) -> Vector {

--- a/src/interaction_box.rs
+++ b/src/interaction_box.rs
@@ -1,5 +1,5 @@
+use super::Vector;
 use raw;
-use Vector;
 
 pub struct InteractionBox {
     raw: *mut raw::InteractionBox,

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -1,6 +1,7 @@
 use libc::c_void;
+
+use super::Controller;
 use raw;
-use Controller;
 
 pub trait Listener: Sized {
     fn on_exit(&mut self, &Controller) {}

--- a/src/pointable.rs
+++ b/src/pointable.rs
@@ -1,6 +1,7 @@
-use raw;
 use std::os::raw::c_int;
-use Vector;
+
+use super::Vector;
+use raw;
 
 pub struct Pointable {
     raw: *mut raw::Pointable,

--- a/src/raw/finger.rs
+++ b/src/raw/finger.rs
@@ -1,5 +1,6 @@
-use super::Vector;
 use std::os::raw::{c_float, c_int};
+
+use super::Vector;
 
 pub enum Finger {}
 pub enum FingerList {}

--- a/src/raw/frame.rs
+++ b/src/raw/frame.rs
@@ -1,8 +1,6 @@
-use super::FingerList;
-use super::HandList;
-use super::InteractionBox;
-use super::PointableList;
 use std::os::raw::c_float;
+
+use super::{FingerList, HandList, InteractionBox, PointableList};
 
 pub enum Frame {}
 

--- a/src/raw/hand.rs
+++ b/src/raw/hand.rs
@@ -1,5 +1,6 @@
-use super::Vector;
 use std::os::raw::{c_float, c_int};
+
+use super::{FingerList, PointableList, Vector};
 
 pub enum Hand {}
 pub enum HandList {}
@@ -7,6 +8,8 @@ pub enum HandList {}
 extern "C" {
     pub fn lm_hand_id(this: *mut Hand) -> i32;
     pub fn lm_hand_pinch_distance(this: *mut Hand) -> c_float;
+    pub fn lm_hand_fingers(this: *mut Hand) -> *mut FingerList;
+    pub fn lm_hand_pointables(this: *mut Hand) -> *mut PointableList;
     pub fn lm_hand_stabilized_palm_position(this: *mut Hand) -> *mut Vector;
     pub fn lm_hand_direction(this: *mut Hand) -> *mut Vector;
     pub fn lm_hand_delete(this: *mut Hand);

--- a/src/raw/listener.rs
+++ b/src/raw/listener.rs
@@ -1,5 +1,6 @@
-use super::Controller;
 use libc::c_void;
+
+use super::Controller;
 
 pub type Listener = *mut c_void;
 pub type ListenerHandler = unsafe extern "C" fn(Listener, *const Controller);

--- a/src/raw/pointable.rs
+++ b/src/raw/pointable.rs
@@ -1,5 +1,6 @@
-use super::Vector;
 use std::os::raw::{c_float, c_int};
+
+use super::Vector;
 
 pub enum Pointable {}
 pub enum PointableList {}

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,5 +1,6 @@
-use raw;
 use std::ops::{Mul, MulAssign};
+
+use raw;
 
 pub struct Vector {
     raw: *mut raw::Vector,

--- a/wrapper/hand.cpp
+++ b/wrapper/hand.cpp
@@ -2,6 +2,7 @@
 #include <Leap.h>
 #include "hand.h"
 #include "finger.h"
+#include "pointable.h"
 #include "vector.h"
 #include "list.h"
 
@@ -17,6 +18,14 @@ extern "C" {
     float lm_hand_pinch_distance(LM_Hand self) {
         // TODO: use pinchDistance() once Leap SDK 3.x releases
         return self->pinchStrength();
+    }
+
+    LM_FingerList lm_frame_fingers(LM_Hand self) {
+        return new Leap::FingerList(self->fingers());
+    }
+
+    LM_PointableList lm_frame_pointables(LM_Hand self) {
+        return new Leap::PointableList(self->pointables());
     }
 
     LM_Vector lm_hand_stabilized_palm_position(LM_Hand self) {

--- a/wrapper/hand.cpp
+++ b/wrapper/hand.cpp
@@ -20,11 +20,11 @@ extern "C" {
         return self->pinchStrength();
     }
 
-    LM_FingerList lm_frame_fingers(LM_Hand self) {
+    LM_FingerList lm_hand_fingers(LM_Hand self) {
         return new Leap::FingerList(self->fingers());
     }
 
-    LM_PointableList lm_frame_pointables(LM_Hand self) {
+    LM_PointableList lm_hand_pointables(LM_Hand self) {
         return new Leap::PointableList(self->pointables());
     }
 


### PR DESCRIPTION
During a project I was working on, I had implemented a few other minor things after #2 was merged. I thought it would be nice to pull request these too.

The changes a little, and quite random. Here is a summary:
- Implement functions for getting `Finger`s and `Pointable`s being part of a `Hand`.
- Derive additional traits on `FingerType` to allow debugging and comparison.
- `std::thread::sleep_ms()` is now deprecated, I've replaced these calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/leap-rs/3)
<!-- Reviewable:end -->
